### PR TITLE
Quality updates

### DIFF
--- a/voxel_view/CMakeLists.txt
+++ b/voxel_view/CMakeLists.txt
@@ -28,7 +28,7 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/source/common/SourcePath.cpp.in ${CMAKE_SOURC
 include_directories(${CMAKE_SOURCE_DIR}/source/common
 						  ${CMAKE_SOURCE_DIR}/source
 						  ${CMAKE_SOURCE_DIR}/shaders)
-add_executable(voxel_view  MACOSX_BUNDLE
+add_executable(voxel_view WIN32 MACOSX_BUNDLE
 	source/voxel_view.cpp
 	source/VoxelGrid.cpp
 	source/VoxelGrid.h

--- a/voxel_view/CMakeLists.txt
+++ b/voxel_view/CMakeLists.txt
@@ -28,7 +28,7 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/source/common/SourcePath.cpp.in ${CMAKE_SOURC
 include_directories(${CMAKE_SOURCE_DIR}/source/common
 						  ${CMAKE_SOURCE_DIR}/source
 						  ${CMAKE_SOURCE_DIR}/shaders)
-add_executable(voxel_view WIN32 MACOSX_BUNDLE
+add_executable(voxel_view  MACOSX_BUNDLE
 	source/voxel_view.cpp
 	source/VoxelGrid.cpp
 	source/VoxelGrid.h
@@ -42,6 +42,8 @@ add_executable(voxel_view WIN32 MACOSX_BUNDLE
 	source/common/Trackball.cpp
 	source/common/Trackball.h
 	source/common/vec.h
+	source/common/u8names.h
+	source/common/u8names.cpp
 	shaders/fshader.glsl
     shaders/vshader.glsl)
 

--- a/voxel_view/source/common/common.h
+++ b/voxel_view/source/common/common.h
@@ -57,11 +57,21 @@ namespace Angel {
 #include "vec.h"
 #include "mat.h"
 //#include "CheckError.h"
+#ifdef _WIN32
+#include "u8names.h"
+#endif //_WIN32
 
 static char*
 readShaderSource(const char* shaderFile)
 {
+#ifdef _WIN32
+  std::wstring wcfn;
+  if (u8names_towc(shaderFile, wcfn) != 0)
+    return NULL;
+  FILE* fp = _wfopen(wcfn.c_str(), L"rb");
+#else
   FILE* fp = fopen(shaderFile, "rb");
+#endif //_WIN32
   
   if ( fp == NULL ) { return NULL; }
   

--- a/voxel_view/source/common/readvoxel.cpp
+++ b/voxel_view/source/common/readvoxel.cpp
@@ -1,5 +1,6 @@
 
 #include "readvoxel.h"
+#include "u8names.h"
 #include <qbvoxel/parse.h>
 #include <cstdio>
 #include <cerrno>
@@ -91,7 +92,17 @@ voxelgrid_decode(std::vector<unsigned char>& image,
   unsigned int& width, unsigned int& height, unsigned int &depth,
   const char* path)
 {
+#ifdef _WIN32
+  std::FILE* fp ;
+  /* */{
+    std::wstring wcpath;
+    if (u8names_towc(path, wcpath) != 0)
+      return 9/* other io */;
+    fp = _wfopen(wcpath.c_str(), L"rb");
+  }
+#else
   std::FILE* fp = std::fopen(path, "rb");
+#endif //_WIN32
   if (fp != NULL) {
     unsigned int error_code = 0;
     unsigned char buf[256];

--- a/voxel_view/source/common/u8names.cpp
+++ b/voxel_view/source/common/u8names.cpp
@@ -1,0 +1,66 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  --- u8names.cpp ---
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "u8names.h"
+#include <errno.h>
+
+static
+unsigned int u8names_bytecount(unsigned char lead_ch) {
+  if (lead_ch < 0xC0) {
+    errno = EILSEQ;
+    return 1;
+  }
+  else if (lead_ch < 0xE0)
+    return 2;
+  else if (lead_ch < 0xF0)
+    return 3;
+  else if (lead_ch < 0xF8)
+    return 4;
+  else {
+    errno = EILSEQ;
+    return 1;
+  }
+}
+
+int u8names_towc(const char* nm, std::wstring& out) {
+  const unsigned char* p;
+  for (p = reinterpret_cast<const unsigned char*>(nm); *p; ++p) {
+    const unsigned char v = *p;
+    if (v < 0x80) {
+      /* Latin-1 compatibility */
+      out.push_back(v);
+    }
+    else if (v < 0xC0) {
+      errno = EILSEQ;
+      return EILSEQ;
+    }
+    else {
+      const unsigned int i_count = u8names_bytecount(v);
+      if (i_count == 1) {
+        return EILSEQ;
+      }
+      /* check extension codes */
+      unsigned int i;
+      unsigned long int qv = v & (31u >> (i_count - 2u));
+      for (i = 1; i < i_count; ++i) {
+        unsigned char const v1 = *(p + i);
+        if (v1 < 0x80 || v1 >= 0xC0) {
+          errno = EILSEQ;
+          return EILSEQ;
+        }
+        else qv = (qv << 6) | (v1 & 63);
+      }
+      if (qv >= 0x10000) {
+        const unsigned long int qv_m1 = qv - 0x10000;
+        out.push_back(static_cast<wchar_t>(0xD800 | ((qv_m1 >> 10) & 1023)));
+        out.push_back(static_cast<wchar_t>(0xDC00 | (qv_m1 & 1023)));
+      }
+      else out.push_back(static_cast<wchar_t>(qv));
+      p += i_count - 1;
+    }
+  }
+  return 0;
+}

--- a/voxel_view/source/common/u8names.h
+++ b/voxel_view/source/common/u8names.h
@@ -1,0 +1,21 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  --- u8names.h ---
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef hg_SourceCommon_u8names_h_
+#define hg_SourceCommon_u8names_h_
+
+#include <string>
+
+/**
+  Convert a UTF-8 encoded file name to a wchar_t-based filename
+    for use with _wfopen.
+  @param nm file name to convert
+  @param[out] out wchar_t file name written here
+  @return zero on success, nonzero on conversion error
+**/
+int u8names_towc(const char* nm, std::wstring& out);
+
+#endif //hg_SourceCommon_u8names_h_

--- a/voxel_view/source/common/vec.h
+++ b/voxel_view/source/common/vec.h
@@ -24,8 +24,11 @@ struct vec2 {
     //
     //  --- Constructors and Destructors ---
     //
+    
+    vec2( ) :
+	x(GLfloat(0.0)), y(GLfloat(0.0)) {}
 
-    vec2( GLfloat s = GLfloat(0.0) ) :
+    explicit vec2( GLfloat s ) :
 	x(s), y(s) {}
 
     vec2( GLfloat x, GLfloat y ) :
@@ -164,7 +167,10 @@ struct vec3 {
     //  --- Constructors and Destructors ---
     //
 
-    vec3( GLfloat s = GLfloat(0.0) ) :
+    vec3() :
+    x(GLfloat(0.0)), y(GLfloat(0.0)), z(GLfloat(0.0)) {}
+
+    explicit vec3( GLfloat s ) :
 	x(s), y(s), z(s) {}
 
     vec3( GLfloat x, GLfloat y, GLfloat z ) :
@@ -314,7 +320,10 @@ struct vec4 {
     //  --- Constructors and Destructors ---
     //
 
-    vec4( GLfloat s = GLfloat(0.0) ) :
+    vec4(  ) :
+	x(GLfloat(0.0)), y(GLfloat(0.0)), z(GLfloat(0.0)), w(GLfloat(0.0)) {}
+
+    explicit vec4( GLfloat s ) :
 	x(s), y(s), z(s), w(s) {}
 
     vec4( GLfloat x, GLfloat y, GLfloat z, GLfloat w ) :

--- a/voxel_view/source/voxel_view.cpp
+++ b/voxel_view/source/voxel_view.cpp
@@ -194,6 +194,24 @@ void init(){
   for(unsigned int i=0; i < _TOTAL_IMAGES; i++){
     voxelgrid.push_back((source_path + files[i]).c_str());
 
+    // match normal array size of vertices
+    if (voxelgrid[i].normals.size() < voxelgrid[i].vertices.size()) {
+      std::size_t oldsize = voxelgrid[i].normals.size();
+      std::size_t newsize = voxelgrid[i].vertices.size();
+      voxelgrid[i].normals.resize(newsize);
+      for (std::size_t j = oldsize; j < newsize; ++j) {
+        voxelgrid[i].normals[j] = vec3(0.f, -1.f, 0.f);
+      }
+    }
+    if (voxelgrid[i].colors.size() < voxelgrid[i].vertices.size()) {
+      std::size_t oldsize = voxelgrid[i].colors.size();
+      std::size_t newsize = voxelgrid[i].vertices.size();
+      voxelgrid[i].colors.resize(newsize);
+      for (std::size_t j = oldsize; j < newsize; ++j) {
+        voxelgrid[i].colors[j] = vec3(0.f, 0.f, 0.f);
+      }
+    }
+
     glBindVertexArray( vao[i] );
     glBindBuffer( GL_ARRAY_BUFFER, buffer[i] );
     unsigned int vertices_bytes = voxelgrid[i].vertices.size()*sizeof(vec4);

--- a/voxel_view/source/voxel_view.cpp
+++ b/voxel_view/source/voxel_view.cpp
@@ -202,17 +202,24 @@ void init(){
     
     glBufferData( GL_ARRAY_BUFFER, vertices_bytes + colors_bytes + normals_bytes, NULL, GL_STATIC_DRAW );
     unsigned int offset = 0;
-    glBufferSubData( GL_ARRAY_BUFFER, offset, vertices_bytes, &voxelgrid[i].vertices[0] );
+    if (vertices_bytes > 0) {
+      glBufferSubData( GL_ARRAY_BUFFER, offset, vertices_bytes, &voxelgrid[i].vertices[0] );
+    }
     offset += vertices_bytes;
-    glBufferSubData( GL_ARRAY_BUFFER, offset, colors_bytes,  &voxelgrid[i].colors[0] );
+    if (colors_bytes > 0) {
+      glBufferSubData( GL_ARRAY_BUFFER, offset, colors_bytes,  &voxelgrid[i].colors[0] );
+    }
     offset += colors_bytes;
-    glBufferSubData( GL_ARRAY_BUFFER, offset, normals_bytes,  &voxelgrid[i].normals[0] );
+    if (normals_bytes > 0) {
+      glBufferSubData( GL_ARRAY_BUFFER, offset, normals_bytes,  &voxelgrid[i].normals[0] );
+    }
     
     glEnableVertexAttribArray( vColor );
     glEnableVertexAttribArray( vPosition );
     glEnableVertexAttribArray( vNormal );
 
-    glVertexAttribPointer( vPosition, 4, GL_FLOAT, GL_FALSE, 0, BUFFER_OFFSET(0) );
+    if (vertices_bytes > 0)
+      glVertexAttribPointer( vPosition, 4, GL_FLOAT, GL_FALSE, 0, BUFFER_OFFSET(0) );
     if (colors_bytes > 0)
       glVertexAttribPointer( vColor, 3, GL_FLOAT, GL_FALSE, 0, BUFFER_OFFSET(static_cast<size_t>(vertices_bytes)) );
     if (normals_bytes > 0)


### PR DESCRIPTION
- Remove potential pitfalls when working with `Angel::vec`N classes. (for example, `vec3 v = (1,0,2);` silently doing the wrong thing)
- Add support for Unicode file names on Windows.
- Fill in missing vertex data to avoid missing renders on macOS
- Check for empty vertex data before use